### PR TITLE
Fixed not working Separator in Subheading block

### DIFF
--- a/src/settings/ui/block.ts
+++ b/src/settings/ui/block.ts
@@ -663,13 +663,10 @@ class SubheadingModal extends GenericModal<SubHeadingItem> {
             .setName("Separator")
             .setDesc("Text separating properties")
             .addText((t) => {
-                if (!this.block.separator) {
-                    this.block.separator = " ";
-
-                    t.setValue(this.block.separator).onChange((v) => {
-                        this.block.separator = v;
-                    });
-                }
+                t.setValue(this.block.separator).onChange((v) => {
+                    //If onchange(v) parameter is empty, get default ", " or v value
+                    this.block.separator = (v ?? "").trim().length === 0 ? ", " : v;
+                });
             });
     }
 }

--- a/src/view/ui/Subheading.svelte
+++ b/src/view/ui/Subheading.svelte
@@ -17,7 +17,7 @@
 
 {#if subheading.length}
     <div class="subheading">
-        <TextContent textToRender={subheading.join(item.separator ?? " ")} />
+        <TextContent textToRender={subheading.join(item.separator)} />
     </div>
 {/if}
 

--- a/types/layout.ts
+++ b/types/layout.ts
@@ -102,7 +102,7 @@ type SpellsProps = {
 };
 type SubHeadingProps = {
     type: "subheading";
-    separator?: string;
+    separator: string;
 };
 type TableProps = {
     type: "table";


### PR DESCRIPTION
Separator in Subheading block was not working correctly. Anything written in it was ignored and default value (" ") was used.

1. Changed separator from optional value to mandatory value (Reason: when using parameter in join, it takes any string passed on)
2. item.Separator in view was never null
3. Deleted invalid if from Subheading modal 

BEGIN_COMMIT_OVERRIDE
fix: Respect subheading separator in layouts
END_COMMIT_OVERRIDE