### PR TITLE
Extract monster subtypes from 5e.tools tags

### DIFF
--- a/src/importers/5eToolsImport.ts
+++ b/src/importers/5eToolsImport.ts
@@ -193,11 +193,11 @@ function getSubType(type: Creature5eTools["type"]) {
         return;
     }
     let result: string[] = [];
-    for (const subtype in type.tags) {
-        if (typeof subtype == "string") {
-            result.push(subtype);
+    for (var i in type.tags) {
+        if (typeof type.tags[i] == "string") {
+            result.push(type.tags[i]);
         } else {
-            result.push(subtype.tag);
+            result.push(type.tags[i].tag);
         }
     }
     return result.toString();

--- a/src/importers/5eToolsImport.ts
+++ b/src/importers/5eToolsImport.ts
@@ -193,14 +193,14 @@ function getSubType(type: Creature5eTools["type"]) {
         return;
     }
     let result: string[] = [];
-    for (var i in type.tags) {
-        if (typeof type.tags[i] == "string") {
-            result.push(type.tags[i]);
+    for (var t of type.tags) {
+        if (typeof t == "string") {
+            result.push(t);
         } else {
-            result.push(type.tags[i].tag);
+            result.push(t.tag);
         }
     }
-    return result.toString();
+    return result.join(", ");
 }
 
 function getCR(type: Creature5eTools["cr"]) {

--- a/src/importers/5eToolsImport.ts
+++ b/src/importers/5eToolsImport.ts
@@ -72,7 +72,7 @@ export async function build5eMonsterFromFile(file: File): Promise<Monster[]> {
                             name: monster.name,
                             source: getSource(monster),
                             type: getType(monster.type),
-                            subtype: "",
+                            subtype: getSubType(monster.type),
                             size: SIZE_ABV_TO_FULL[monster.size?.[0]],
                             alignment: getMonsterAlignment(monster),
                             hp:
@@ -183,6 +183,26 @@ function getType(type: Creature5eTools["type"]) {
     }
     return type.type;
 }
+
+function getSubType(type: Creature5eTools["type"]) {
+    if (!type) return;
+    if (typeof type == "string") {
+        return;
+    }
+    if (!type.tags) {
+        return;
+    }
+    let result: string[] = [];
+    for (const subtype in type.tags) {
+        if (typeof subtype == "string") {
+            result.push(subtype);
+        } else {
+            result.push(subtype.tag);
+        }
+    }
+    return result.toString();
+}
+
 function getCR(type: Creature5eTools["cr"]) {
     if (!type) return;
     if (typeof type == "string") {

--- a/src/importers/5eToolsImport.ts
+++ b/src/importers/5eToolsImport.ts
@@ -415,8 +415,16 @@ function getAlignmentString(alignment: Align[] | Align | Alignment): string {
     if (!alignment) return null; // used in sidekicks
     let alignments: string[] = [];
     if (Array.isArray(alignment)) {
+        let alignStr: string[] = [];
         for (const align of alignment) {
-            alignments.push(getAlignmentString(align));
+            if (typeof align === "string") {
+                alignStr.push(getAlignmentString(align));
+            } else {
+                alignments.push(getAlignmentString(align));
+            }
+        }
+        if (alignStr.length > 0) {
+            alignments.push(alignStr.join(" "));
         }
     } else if (typeof alignment === "object") {
         if ("special" in alignment && alignment.special != null) {


### PR DESCRIPTION
## Pull Request Description

5e.tools stores monster subtypes in tags.  This PR adds a function to extract subtypes from these tags and add them to the subtype property.

## Changes Proposed

- Add `getSubType` function to extract subtypes from 5e.tools tags

## Related Issues

N/A

## Checklist

<!-- Make sure to check the items below before submitting your pull request -->

- [x] I have read the contribution guidelines and code of conduct.
- [x] I have tested the changes locally and they are working as expected.
- [x] I have added appropriate comments and documentation for the code changes.
- [x] My code follows the coding style and standards of this project.
- [x] I have rebased my branch on the latest main (or master) branch.
- [x] All tests (if applicable) have passed successfully.
- [x] I have run linters and fixed any issues.
- [x] I have checked for any potential security issues or vulnerabilities.

## Screenshots (if applicable)

N/A

## Additional Notes

N/A

BEGIN_COMMIT_OVERRIDE
feat: Extract monster subtypes from 5e.tools tags
END_COMMIT_OVERRIDE
