### PR TITLE
refactor(css): seperate active-heading-font-color from active-font-color

### DIFF
--- a/src/view/Statblock.svelte
+++ b/src/view/Statblock.svelte
@@ -253,7 +253,7 @@
         --active--content-font-size: var(--statblock-content-font-size);
 
         --active--heading-font: var(--statblock-heading-font);
-        --active--heading-font-color: var(--active--font-color);
+        --active--heading-font-color: var(--statblock-heading-font-color);
         --active--heading-font-size: var(--statblock-heading-font-size);
         --active--heading-font-variant: var(--statblock-heading-font-variant);
         --active--heading-font-weight: var(--active--font-weight);


### PR DESCRIPTION
## Pull Request Description

Currently working on adding support for this plugin with my theme and stumbled into this issue.
statblocks sets a css variable called `---statblock-heading-font-color` however it doesn't seem to be used when settting the `--active--heading-font-color`

we don't lose any existing functionality or break existing styles as  `--statblock-heading-font-color` defaults to  `--statblock-font-color` which defaults to `--statblock-primary-color`. this mimics the functionality that `--active-font-color` has as well.

**src/main.css**
```
--statblock-primary-color: #7a200d;
[ ... ]
--statblock-font-color: var(--statblock-primary-color);
[ ... ]
--statblock-heading-font-color: var(--statblock-font-color);
```

**src/view/Statblock.svelte**
```
--active--font-color: var(
    --statblock-font-color,
    --active--primary-color
);
```



## Changes Proposed

<!-- List the main changes and features introduced by this pull request -->

- [x] sets  `--active--heading-font-color` to `--statblock-heading-font-color` instead of  `--active--font-color`

## Related Issues
N/A
<!-- Mention any related issues or tasks that are addressed by this pull request -->

## Checklist

<!-- Make sure to check the items below before submitting your pull request -->

- [x] I have read the contribution guidelines and code of conduct.
- [x] I have tested the changes locally and they are working as expected.
- [x] I have added appropriate comments and documentation for the code changes.
- [x] My code follows the coding style and standards of this project.
- [x] I have rebased my branch on the latest main (or master) branch.
- [x] All tests (if applicable) have passed successfully.
- [x] I have run linters and fixed any issues.
- [x] I have checked for any potential security issues or vulnerabilities.

## Screenshots (if applicable)

if i set `--statblock-heading-font-color` to `#00c2a8` I would expect the heading to change color.

| Current             | With Changes                 |
|---------------------|---------------------|
| ![current-behaviour](https://github.com/javalent/fantasy-statblocks/assets/44450112/61198c57-501d-4adc-93b9-974db6330e33) | ![new-behavior](https://github.com/javalent/fantasy-statblocks/assets/44450112/c3b826ed-c3ef-4692-bc0d-2964c908ae0d) |


<!-- If your changes include visual updates, include relevant screenshots here -->

## Additional Notes
N/A






