### PR TITLE
fix(css): add consistency to css variables for statblocks

### DIFF
--- a/src/view/Statblock.svelte
+++ b/src/view/Statblock.svelte
@@ -261,7 +261,7 @@
 
         --active--property-line-height: var(--statblock-property-line-height);
         --active--property-font-color: var(--active--font-color);
-        --active--property-name-font-color: var(--active--font-color);
+        --active--property-name-font-color: var(--statblock-property-name-font-color);
         --active--property-name-font-weight: var(
             --statblock-property-name-font-weight
         );

--- a/src/view/Statblock.svelte
+++ b/src/view/Statblock.svelte
@@ -273,7 +273,9 @@
             --statblock-section-heading-border-color,
             --active--primary-color
         );
-        --active--section-heading-font-color: var(--active--font-color);
+        --active--section-heading-font-color: var(
+            --statblock-section-heading-font-color
+        );
         --active--section-heading-font-size: var(
             --statblock-section-heading-font-size
         );

--- a/src/view/ui/Traits.svelte
+++ b/src/view/ui/Traits.svelte
@@ -68,6 +68,7 @@
         display: inline;
         font-weight: var(--active--traits-font-weight);
         font-style: var(--active--traits-font-style);
+        color: var(--active--property-name-font-color);
     }
     .statblock-nested-traits {
         margin-left: 1rem;


### PR DESCRIPTION
## Pull Request Description

after #366 was merged I noticed a few other discrepancies so decided to handle them as well.




## Changes Proposed

<!-- List the main changes and features introduced by this pull request -->

- [x] `--active--property-name-font-color` now uses `--statblock-property-name-font-color`
- [x]  `--active--section-heading-border-color` now uses `--statblock-section-heading-font-color`
- [x] Trait property names now use the  `--active--property-name-font-color` which matches current fate-core behavior as well

## Related Issues
N/A
<!-- Mention any related issues or tasks that are addressed by this pull request -->

## Checklist

<!-- Make sure to check the items below before submitting your pull request -->

- [x] I have read the contribution guidelines and code of conduct.
- [x] I have tested the changes locally and they are working as expected.
- [x] I have added appropriate comments and documentation for the code changes.
- [x] My code follows the coding style and standards of this project.
- [x] I have rebased my branch on the latest main (or master) branch.
- [x] All tests (if applicable) have passed successfully.
- [x] I have run linters and fixed any issues.
- [x] I have checked for any potential security issues or vulnerabilities.

## Screenshots (if applicable)


**Property name use css variable changes**
```
:root {
    --statblock-property-name-font-color: var(--dark0);
}
```

|      Before         |         After       |
|---------------------|---------------------|
| ![property-name-before](https://github.com/javalent/fantasy-statblocks/assets/44450112/699e1d15-9955-40fa-b111-28cf79e7e9fa) | ![property-name-after](https://github.com/javalent/fantasy-statblocks/assets/44450112/e6aff2ad-5598-492d-9a25-e033082a48be) |


**Trait property name changes**
```
:root {
    --statblock-property-name-font-color: var(--dark0);
}
```

|      Before         |         After       |
|---------------------|---------------------|
| ![property-name-after](https://github.com/javalent/fantasy-statblocks/assets/44450112/e6aff2ad-5598-492d-9a25-e033082a48be) | ![trait-property-after](https://github.com/javalent/fantasy-statblocks/assets/44450112/0a0cdf29-c55d-4792-a894-b9291112529e) |


**Section heading css variable changes**
:root {
    --statblock-section-heading-font-color: var(--dark0);
}

|      Before         |         After       |
|---------------------|---------------------|
| ![section-heading-before](https://github.com/javalent/fantasy-statblocks/assets/44450112/f3d3dc87-322f-4c0a-80d3-235593e9a7f5) | ![section-heading-after](https://github.com/javalent/fantasy-statblocks/assets/44450112/39155516-c02b-49e1-8099-a3c2a1d382ef)|








<!-- If your changes include visual updates, include relevant screenshots here -->

## Additional Notes
N/A