### PR TITLE
fix(css): prioritize pf2e icons over system font

### DIFF
--- a/src/layouts/pathfinder 2e/xCSS/pf2e.css
+++ b/src/layouts/pathfinder 2e/xCSS/pf2e.css
@@ -18,6 +18,7 @@ Pathfinder Glyphs Only and any associated classes to call those Glyphs
   font-weight: normal;
   font-style: normal;
   font-display: block;
+  unicode-range: U+2B32, U+2B3A, U+2B3B, U+2B3D, U+2B53;
 }
 [class^=glyph-],
 [class*=" glyph-"] {
@@ -326,11 +327,11 @@ body.pathfinder-2e-settlement-layout-theme-kingmaker .statblock.pathfinder-2e-se
   --statblock-box-shadow-blur: 1.5em;
   --statblock-font-color: rgb(51, 51, 51);
   --statblock-font-weight: 400;
-  --statblock-content-font: system-ui, "Pathfinder", -apple-system,
+  --statblock-content-font: "Pathfinder", system-ui, -apple-system,
   BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
   "Open Sans", "Helvetica Neue", sans-serif;
   --statblock-content-font-size: 13px;
-  --statblock-heading-font: system-ui, "Pathfinder", -apple-system,
+  --statblock-heading-font: "Pathfinder", system-ui, -apple-system,
   BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
   "Open Sans", "Helvetica Neue", sans-serif;
   --statblock-heading-font-color: rgb(51, 51, 51);


### PR DESCRIPTION
## Pull Request Description

When using the plugin on iOS with Pathfinder 2e, the action icons in the bestiary community content, which are ⬽ or similar in the descriptions, don't render using the "Pathfinder" icon font as they do on Windows. This is because the system-ui font takes precedence, and on iOS that font includes these icons.

## Changes Proposed

- [x] Place "Pathfinder" before system-ui in --statblock-content-font and --statblock-heading-font for pf2e.css
- [x] Change the "Pathfinder" @<!-- -->font-face specification so it only includes the icons, the whitespace was breaking things on iOS

## Related Issues

Obsidian-TTRPG-Community/Fantasy-Statblocks-CSS-Development#10

## Checklist

<!-- Make sure to check the items below before submitting your pull request -->

- [x] I have read the contribution guidelines and code of conduct.
- [x] I have tested the changes locally and they are working as expected.
- [x] I have added appropriate comments and documentation for the code changes.
- [x] My code follows the coding style and standards of this project.
- [x] I have rebased my branch on the latest main (or master) branch.
- [x] All tests (if applicable) have passed successfully.
- [x] I have run linters and fixed any issues.
- [x] I have checked for any potential security issues or vulnerabilities.

## Screenshots (if applicable)

| Before | After |
| -------- | ------- |
|  ![Before](https://github.com/javalent/fantasy-statblocks/assets/21015774/3833143d-4790-419d-923d-130893e47602) | ![After](https://github.com/javalent/fantasy-statblocks/assets/21015774/671201b7-9c71-44f9-a25c-1ea2ecfd0b9f) |


## Additional Notes

N/A
