### PR TITLE
feat: Allow markdown formatting in trait names (close #428)

### DIFF
--- a/src/view/ui/Traits.svelte
+++ b/src/view/ui/Traits.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
     import type { SpellsItem, TraitsItem } from "src/layouts/layout.types";
     import { slugify } from "src/util/util";
-    import TextContent from "./TextContent.svelte";
 
     import TextContentHolder from "./TextContentHolder.svelte";
     import type { Monster, Trait } from "index";
@@ -39,7 +38,7 @@
 <div class="property {cssClasses} trait">
     {#if name}
         <div class="property-name trait-name">
-            <TextContent textToRender={name} />
+            <TextContentHolder property={name} />
         </div>
     {/if}
 


### PR DESCRIPTION
## Pull Request Description

Allows markdown formatting in trait names. This gives more freedom to layout authors.

## Changes Proposed

- Change the `TextContent` in `Traits.svelte` to a `TextContentHolder`

## Related Issues
Fixes #428 

## Checklist

- [x] I have read the contribution guidelines and code of conduct.
- [x] I have tested the changes locally and they are working as expected.
- [x] I have added appropriate comments and documentation for the code changes.
- [x] My code follows the coding style and standards of this project.
- [x] I have rebased my branch on the latest main (or master) branch.
- [x] All tests (if applicable) have passed successfully.
- [x] I have run linters and fixed any issues.
- [x] I have checked for any potential security issues or vulnerabilities.