### PR TITLE
feat: Pass the current property as a parameter for trait callbacks

### DIFF
--- a/src/settings/layout/blocks/ui/block.ts
+++ b/src/settings/layout/blocks/ui/block.ts
@@ -999,8 +999,10 @@ class TraitsModal extends MarkdownEnabledModal<TraitsItem> {
                         text: "The callback will receive the "
                     });
                     e.createEl("code", { text: "monster" });
+                    e.createSpan({ text: " and " });
+                    e.createEl("code", { text: "property" });
                     e.createSpan({
-                        text: " parameter. The callback should return a string. For example: "
+                        text: " parameters. The callback should return a string. For example: "
                     });
 
                     e.createEl("code", { text: "return monster.name" });

--- a/src/view/ui/Traits.svelte
+++ b/src/view/ui/Traits.svelte
@@ -17,8 +17,8 @@
         try {
             const frame = document.body.createEl("iframe");
             const funct = (frame.contentWindow as any).Function;
-            const func = new funct("monster", item.callback);
-            desc = func.call(undefined, monster) ?? desc;
+            const func = new funct("monster", "property", item.callback);
+            desc = func.call(undefined, monster, trait) ?? desc;
             document.body.removeChild(frame);
         } catch (e) {
             new Notice(


### PR DESCRIPTION
## Pull Request Description
This allows layout authors to write custom callbacks which can refer back to the trait for that callback. With the current implementation, the callback has access to the monster, but no reference to the current trait being rendered, which makes the utility very limited (eg every trait description would be the same)

## Changes Proposed
- [x] Pass in the entire trait object as the `property` parameter for trait callbacks
- [x] Update settings help text with new parameter information

## Related Issues
I didn't make a feature request for this one. Let me know if you'd like me to.

## Checklist
- [x] I have read the contribution guidelines and code of conduct.
- [x] I have tested the changes locally and they are working as expected.
- [x] I have added appropriate comments and documentation for the code changes.
- [x] My code follows the coding style and standards of this project.
- [x] I have rebased my branch on the latest main (or master) branch.
- [x] All tests (if applicable) have passed successfully.
- [x] I have run linters and fixed any issues.
- [x] I have checked for any potential security issues or vulnerabilities.

## Additional Notes
As far as I can tell this shouldn't break any existing layouts. The only potential issue I can think of is if any existing layouts use the `property` variable in a trait callback, but I think in that case it would actually just get locally overridden - but I'm not 100% sure and haven't checked as it seems like a very edge case.