### PR TITLE
fix: Fix stringifier incorrectly matching some links

### DIFF
--- a/src/parser/stringifier.ts
+++ b/src/parser/stringifier.ts
@@ -32,11 +32,11 @@ export class LinkStringifier {
      */
     static transformSource(source: string) {
         return source
-            .replace(/\[\[([\s\S]+?)\]\]/g, (_, $1) =>
+            .replace(/\[\[([^]]+?)\]\]/g, (_, $1) =>
                 LinkStringifier.replaceWikiLink($1)
             )
             .replace(
-                /\[([\s\S]*?)\]\(([\s\S]+?)\)/g,
+                /\[([^]]*?)\]\(([^)]+?)\)/g,
                 (_, alias: string, path: string) =>
                     LinkStringifier.replaceMarkdownLink(path, alias)
             );


### PR DESCRIPTION
## Pull Request Description
The previous regex would match the following:
```
abilityMods: [4, 2, 3, -3, 1, -1]
resistances: "[Some Link](note.md)"
```

So that that the first group (the link text) would match:
```
4, 2, 3, -3, 1, -1]
resistances: "[Some Link
```
and the second group (the path) would match:
```
note.md
```

This commit changes the regex so that it doesn't falsely match in these cases and instead just matches the actual markdown link.

## Changes Proposed

- [x] Fix the wiki link and markdown link matching regexes to match until they find an end bracket rather than matching past an end bracket until they find the rest of the match.

## Checklist

- [x] I have read the contribution guidelines and code of conduct.
- [x] I have tested the changes locally and they are working as expected.
- [x] I have added appropriate comments and documentation for the code changes.
- [x] My code follows the coding style and standards of this project.
- [x] I have rebased my branch on the latest main (or master) branch.
- [x] All tests (if applicable) have passed successfully.
- [x] I have run linters and fixed any issues.
- [x] I have checked for any potential security issues or vulnerabilities.