### PR TITLE
Update TetraCube Importing (Fix for Issue #316 included)

### DIFF
--- a/src/importers/TetraCubeImport.ts
+++ b/src/importers/TetraCubeImport.ts
@@ -274,7 +274,7 @@ class TetraMonster {
             legendary_description: (monster.isLegendary ?? false) ? monster.legendariesDescription : null,
             legendary_actions: (monster.isLegendary ?? false) ? importer.getTraits(monster.legendaries) : null,
             mythic_description: (monster.isMythic ?? false) ? monster.mythicDescription : null,
-            mythic_actions: (monster.ismythic ?? false) ? importer.getTraits(monster.mythics) : null,
+            mythic_actions: (monster.isMythic ?? false) ? importer.getTraits(monster.mythics) : null,
             lair_description: (monster.isLair ?? false) ? monster.lairDescription : null,
             lair_actions: (monster.isLair ?? false) ? importer.getTraits(monster.lairs) : null,
             lair_description_end: (monster.isLair ?? false) ? monster.lairDescriptionEnd : null,

--- a/src/importers/TetraCubeImport.ts
+++ b/src/importers/TetraCubeImport.ts
@@ -243,7 +243,7 @@ class TetraMonster {
             name: monster.name,
             source: "TetraCube",
             type: monster.type,
-            subtype: "",
+            subtype: monster.tag,
             size: monster.size,
             alignment: monster.alignment,
             hp: importer.getHP(monster)?.hp,
@@ -269,8 +269,18 @@ class TetraMonster {
             cr: monster.cr ?? "",
             traits: importer.getTraits(monster.abilities),
             actions: importer.getTraits(monster.actions),
+            bonus_actions: importer.getTraits(monster.bonusActions),
             reactions: importer.getTraits(monster.reactions),
-            legendary_actions: importer.getTraits(monster.legendaries),
+            legendary_description: (monster.isLegendary ?? false) ? monster.legendariesDescription : null,
+            legendary_actions: (monster.isLegendary ?? false) ? importer.getTraits(monster.legendaries) : null,
+            mythic_description: (monster.isMythic ?? false) ? monster.mythicDescription : null,
+            mythic_actions: (monster.ismythic ?? false) ? importer.getTraits(monster.mythics) : null,
+            lair_description: (monster.isLair ?? false) ? monster.lairDescription : null,
+            lair_actions: (monster.isLair ?? false) ? importer.getTraits(monster.lairs) : null,
+            lair_description_end: (monster.isLair ?? false) ? monster.lairDescriptionEnd : null,
+            regional_description: (monster.isRegional ?? false) ? monster.regionalDescription : null,
+            regional_actions: (monster.isRegional ?? false) ? importer.getTraits(monster.regionals) : null,
+            regional_description_end: (monster.isRegional ?? false) ? monster.regionalDescriptionEnd : null,
             spells: importer.getSpells(monster.abilities)
         };
         return importedMonster;


### PR DESCRIPTION
## Pull Request Description

Update the importer from TetraCube to include subtype, bonus actions, mythic actions, lair actions, and regional effects.

<!-- Briefly describe the purpose of this pull request -->

The purpose of the pull request is to update the TetraCube importer to include missing elements.

## Changes Proposed

<!-- List the main changes and features introduced by this pull request -->

- [x] Update the TetraCube importer to recognize subtype of monsters
- [x] Update the TetraCube importer to recognize bonus actions of monsters
- [x] Update the TetraCube importer to recognize mythic actions of monsters
- [x] Update the TetraCube importer to recognize lair actions of monsters
- [x] Update the TetraCube importer to recognize regional effects of monsters

## Related Issues

<!-- Mention any related issues or tasks that are addressed by this pull request -->

Fixes #316 

## Checklist

<!-- Make sure to check the items below before submitting your pull request -->

- [X] I have read the contribution guidelines and code of conduct.
- [X] I have tested the changes locally and they are working as expected.
- [X] I have added appropriate comments and documentation for the code changes.
- [X] My code follows the coding style and standards of this project.
- [X] I have rebased my branch on the latest main (or master) branch.
- [X] All tests (if applicable) have passed successfully.
- [X] I have run linters and fixed any issues.
- [X] I have checked for any potential security issues or vulnerabilities.

## Screenshots (if applicable)

<!-- If your changes include visual updates, include relevant screenshots here -->

## Additional Notes

<!-- Any additional information or context you want to provide about the pull request -->
