### PR TITLE
✨ allow traits for saves and skills

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -19,6 +19,9 @@ export type fage_ability =
     | "strength"
     | "willpower";
 
+export type AbilitySkill = { [key: string]: number }
+export type TraitAbilitySkill = Trait | AbilitySkill;
+
 export interface Monster {
     image?: string;
     name: string;
@@ -42,8 +45,8 @@ export interface Monster {
         number,
         number
     ];
-    saves?: { [K in ability]?: number } | { [K in ability]?: number }[];
-    skillsaves?: { [key: string]: number } | { [key: string]: number }[];
+    saves?: AbilitySkill | TraitAbilitySkill[];
+    skillsaves?: AbilitySkill | TraitAbilitySkill[];
     damage_vulnerabilities: string;
     damage_resistances: string;
     damage_immunities: string;

--- a/src/view/ui/Saves.svelte
+++ b/src/view/ui/Saves.svelte
@@ -36,7 +36,13 @@
 
     const saves = arr
         .map((ability) => {
-            if (typeof ability != "object" || ability == null) return null;
+            if (!ability || typeof ability !== "object") return null;
+
+            if (ability.desc) {
+                // Trait with a description
+                return [ability.name || "_", ability.desc];
+            }
+
             let key = Object.keys(ability)[0];
             if (!key) return null;
             const value = Object.values(ability)[0];
@@ -60,9 +66,11 @@
         <div class="property-text">
             {#each saves as [name, value]}
                 <div class="save-entry save-{slugify(name)}-entry">
+                    {#if !name.startsWith('_')}
                     <div class="save-name">
                         <TextContentHolder property={name} />
                     </div>
+                    {/if}
                     <div class="save-value">
                         <TextContentHolder property={value} />
                     </div>


### PR DESCRIPTION
## Pull Request Description

Update skills and saves to accept/display traits as well (`name`/`desc`).

Ignore name fields that start with `_`.

## Checklist

<!-- Make sure to check the items below before submitting your pull request -->

- [x] I have read the contribution guidelines and code of conduct.
- [x] I have tested the changes locally and they are working as expected.
- [x] I have added appropriate comments and documentation for the code changes.
- [x] My code follows the coding style and standards of this project.
- [x] I have rebased my branch on the latest main (or master) branch.
- [x] All tests (if applicable) have passed successfully.
- [x] I have run linters and fixed any issues.
- [x] I have checked for any potential security issues or vulnerabilities.

## Screenshots (if applicable)

```yaml
"saves":
- "intelligence": !!int "7"
- "charisma": !!int "5"
"skillsaves":
- "name": "[Deception](rules/skills.md#Deception)"
  "desc": "+5"
- "name": "[Perception](rules/skills.md#Perception)"
  "desc": "+4"
- "desc": "One of [Arcana](rules/skills.md#Arcana) +7, [History](rules/skills.md#History)\
    \ +7, [Nature](rules/skills.md#Nature) +7, or [Religion](rules/skills.md#Religion)\
    \ +7"
"condition_immunities": "[blinded](rules/conditions.md#Blinded), [charmed](rules/conditions.md#Charmed),\
  \ [deafened](rules/conditions.md#Deafened), [exhaustion](rules/conditions.md#Exhaustion),\
  \ [prone](rules/conditions.md#Prone)"
```

<img width="467" alt="image" src="https://github.com/user-attachments/assets/930e3dde-8594-4213-b526-aad8c62f7179" />

BEGIN_COMMIT_OVERRIDE
feat: Allow traits for `saves` type properties
END_COMMIT_OVERRIDE
