### PR TITLE
Use weapon name instead of 'Melee' to prevent overwrite during import

### DIFF
--- a/src/importers/PathbuilderImport.ts
+++ b/src/importers/PathbuilderImport.ts
@@ -196,7 +196,7 @@ function getWeapons(weapons: Weapon[]): Trait[] {
             damage_die="3"
         }
         return {
-            name: "Melee",
+            name: weapon.name,
             desc: ONE_ACTION + `[[${weapon.name}|${weapon.display}]] ${addSign(weapon.attack)} __Damage__ ${damage_die}${weapon.die}${damage_bonus} _(${weapon.damageType})_` 
         };
     });


### PR DESCRIPTION
## Pull Request Description

The Pathbuilder2e importer gave all weapons the same name ("Melee"), which caused them to overwrite each other in the imported data so that only the last listed weapon was saved. This change uses the name of the weapon from the source data as the map key rather than the fixed string, so that all of the weapon attacks are listed in the output.

## Changes Proposed

src/importers/PathbuilderImport.ts:199 - Use `weapon.name` instead of "Melee" for the trait name.

## Related Issues

Possibly: **Abilities with duplicate names not showing up #483**, but I have not verified that.

## Checklist

<!-- Make sure to check the items below before submitting your pull request -->

- [x] I have read the contribution guidelines and code of conduct.
- [x] I have tested the changes locally and they are working as expected.
- [x] I have added appropriate comments and documentation for the code changes.
- [x] My code follows the coding style and standards of this project.
- [x] I have rebased my branch on the latest main (or master) branch.
- [x] All tests (if applicable) have passed successfully.
- [x] I have run linters and fixed any issues.
- [x] I have checked for any potential security issues or vulnerabilities.

## Additional Notes

BEGIN_COMMIT_OVERRIDE
fix: Fixes weapon name when using the pathfinder importer
END_COMMIT_OVERRIDE